### PR TITLE
interactive selection of groups

### DIFF
--- a/bin/ufcc
+++ b/bin/ufcc
@@ -7,9 +7,9 @@ r"""Argument parser to use ufcc from the command-line
 """
 
 import argparse
-import MDAnalysis as mda
 import ufcc._version as vers
 from ufcc import UFCC
+from ufcc.interactive_sel import interactive_selection
 from time import perf_counter
 import warnings
 from fpdf import FPDF
@@ -64,109 +64,7 @@ with warnings.catch_warnings(record=True) as w:
 
 # For interactive selection of the groups for the contacts calculation
 if args.i_bool:
-    db_qr = {
-       'Database' : target_system.database.selected,
-        'Query' : target_system.query.selected
-    }
-
-    groups_dict = {
-        0: ['System', target_system.query.whole.universe.atoms],
-        1: ['Protein', target_system.query.whole],
-        2: ['Lipids', target_system.database.whole]
-    }
-
-    groups_to_add = target_system.database.whole.universe.select_atoms('not protein').groupby('resnames')
-    for label, ag in groups_to_add.items():
-        groups_dict[max(groups_dict.keys()) + 1] = ['{}'.format(label), ag]
-
-    def print_action_keys():
-        print('''\nActions keys:
-db  :  update database group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
-qr  :  update query group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
-gp :  create subgroups grouped by any topology attribute ("names", "resnames", "masses", etc). (i.e. >> gp Group_ID resnames) creates new groups for every different resname in the Group_ID selected.
-sl  :  create new groups by splitting a previous group at the desired level ("segment", "residue", "atom", "molecule"). (i.e. >> sl Group_ID residue) splits the Group_ID selected into all the residues that make it up, and create a new group for each of them.
-add:  merge two or more groups and create a new group with the combination. (i.e. >> add Group_ID1 Group_ID2 ... Group_IDn) creates a new group for the combination of the groups Group_ID1 Group_ID2 ... Group_IDn.
-del:  delete a group from the list of groups. (i.e. >> del Group_ID) remove the Group_ID selected.
-lg :  print the list of groups.
-h  :  print the help for all the available action keys.
-e  :  exit interactive selection and calculate de contacts between the Query and Database groups. 
-''')
-
-    def print_list_groups():
-        print('\nSelection groups:\n')
-        for key, value in groups_dict.items():
-            print('({}) : {} --> {} atoms'.format(key, value[0], value[1].n_atoms))
-
-    def print_db_qr():
-        print('\nDatabase and Query groups:\n')
-        for key, value in db_qr.items():
-            print('{} --> {} atoms'.format(key, value.n_atoms))
-        print('-----------------------------------------------------')
-        
-    def print_help_message():
-        print('You can type (lg) to list the groups at any time, or (h) to review the available action keys with examples.')
-
-    def add_atomgroups(ag_list):
-        combined = ag_list[0]
-        for ag in ag_list[1:]:
-            combined = mda.Merge(combined, ag)
-        return combined
-
-    print_db_qr()
-    print_list_groups()
-    print_action_keys()
-    
-    input_key = ''
-    while input_key != 'e':
-        print_help_message()
-        input_key = input('>> ')
-        if input_key != 'e' and len(input_key) > 0:
-            input_list = input_key.split()
-
-            # updating database and query groups
-            if input_list[0] == 'db':
-                target_system.database.select(groups_dict[int(input_list[1])][1])
-                groups_dict[0][1] = groups_dict[int(input_list[1])][1]
-            elif input_list[0] == 'qr':
-                target_system.query.select(groups_dict[int(input_list[1])][1])
-                groups_dict[1][1] = groups_dict[int(input_list[1])][1]
-
-            # creating subgroups
-            elif input_list[0] == 'gb':
-                groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
-                for label, ag in groups_to_add.items():
-                    groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
-            elif input_list[0] == 'sl':
-                groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
-                for ag in groups_to_add:
-                    groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
-
-            # logical operations with groups
-            elif input_list[0] == 'add':
-                ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
-                combined = add_atomgroups(ag_list).atoms
-                groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
-            elif input_list[0] == 'del':
-                groups_dict.pop(int(input_list[1]))
-
-            # help actions
-            elif input_list[0] == 'lg':
-                print_db_qr()
-                print_list_groups()
-            elif input_list[0] == 'h':
-                print_action_keys()
-
-            # exit actions
-            else:
-                print('Unknown action key. Please type (h) to see the available action keys.')
-
-        elif input_key != 'e' and len(input_key) == 0:
-            print_help_message()
-            input_key = input('>> ')
-        else:
-            print('Exiting interactive selection.')
-            break
-
+    target_system = interactive_selection(target_system)
 
 print('\n########### Starting calculation ##########')
 t1 = perf_counter()

--- a/bin/ufcc
+++ b/bin/ufcc
@@ -7,6 +7,7 @@ r"""Argument parser to use ufcc from the command-line
 """
 
 import argparse
+from tkinter import N
 import MDAnalysis as mda
 import ufcc._version as vers
 from ufcc import UFCC
@@ -37,12 +38,11 @@ ufcc_parser.add_argument('-bk', '--backend', metavar='', type=str, help='backend
 ufcc_parser.add_argument('-r', '--report', metavar='', type=bool, help='report file with a summary of warnings and compute statics of your calculation', default=False, nargs='?', const=True, dest='r_bool')
 ufcc_parser.add_argument('-rn', '--report_name', metavar='', type=str, help='name for report file', default='summary_report.pdf', dest='report')
 ufcc_parser.add_argument('-n', '--n_jobs', metavar='', type=int, help='number of CPU cores to use with the parallel backend', default=-1, dest='n_jobs')
+ufcc_parser.add_argument('-i', '--interactive', metavar='', type=bool, help='interactive selection of the atom groups for the calculation of the contacts', default=False, nargs='?', const=True, dest='i_bool')
 
 
 # Executing the parse_args() method
 args = ufcc_parser.parse_args()
-
-print('\n########### Starting calculation ##########')
 
 # Dealing with the MDAnalysis warnings, especially the ones about the mass, as this is quite common when loading Martini systems.
 mass_flag = 0
@@ -63,6 +63,91 @@ with warnings.catch_warnings(record=True) as w:
         print(mass_warn)
         warn2report.append(mass_warn)
 
+# For interactive selection of the groups for the contacts calculation
+if args.i_bool:
+    groups_dict = {
+        0: ['Database', target_system.database.selected],
+        1: ['Query', target_system.query.selected],
+        2: ['System', target_system.query.whole.universe.atoms],
+        3: ['Protein', target_system.query.whole],
+        4: ['Lipids', target_system.database.whole]
+    }
+
+    groups_to_add = target_system.database.whole.universe.select_atoms('not protein').groupby('resnames')
+    for label, ag in groups_to_add.items():
+        groups_dict[max(groups_dict.keys()) + 1] = ['{}'.format(label), ag]
+
+    def print_action_keys():
+        print('''\nActions keys:
+db  :  update database group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
+qr  :  update query group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
+gp :  create subgroups grouped by any topology attribute ("names", "resnames", "masses", etc). (i.e. >> gp Group_ID resnames) creates new groups for every different resname in the Group_ID selected.
+sl  :  create new groups by splitting a previous group at the desired level ("segment", "residue", "atom", "molecule"). (i.e. >> sl Group_ID residue) splits the Group_ID selected into all the residues that make it up, and create a new group for each of them.
+add:  merge two or more groups and create a new group with the combination. (i.e. >> add Group_ID1 Group_ID2 ... Group_IDn) creates a new group for the combination of the groups Group_ID1 Group_ID2 ... Group_IDn.
+del:  delete a group from the list of groups. (i.e. >> del Group_ID) remove the Group_ID selected.
+lg :  print the list of groups.
+h  :  print the help for all the available action keys.
+e  :  exit interactive selection and calculate de contacts between the Query and Database groups. 
+''')
+
+    def print_list_groups():
+        print('\nList of groups:\n')
+        for key, value in groups_dict.items():
+            print('({}) : {} --> {} atoms'.format(key, value[0], value[1].n_atoms))
+        
+    def print_help_message():
+        print('You can type (lg) to list the groups at any time, or (h) to review the available action keys with examples.')
+
+    def add_atomgroups(ag_list):
+        combined = ag_list[0]
+        for ag in ag_list[1:]:
+            combined = mda.Merge(combined, ag)
+        return combined
+
+    print_list_groups()
+    print_action_keys()
+    
+    input_key = ''
+    while input_key != 'e':
+        print_help_message()
+        input_key = input('>> ')
+        if input_key != 'e':
+            input_list = input_key.split()
+
+            # updating database and query groups
+            if input_list[0] == 'db':
+                target_system.database.select(groups_dict[int(input_list[1])][1])
+                groups_dict[0][1] = groups_dict[int(input_list[1])][1]
+            elif input_list[0] == 'qr':
+                target_system.query.select(groups_dict[int(input_list[1])][1])
+                groups_dict[1][1] = groups_dict[int(input_list[1])][1]
+
+            # creating subgroups
+            elif input_list[0] == 'gb':
+                groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
+                for label, ag in groups_to_add.items():
+                    groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
+            elif input_list[0] == 'sl':
+                groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
+                for ag in groups_to_add:
+                    groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
+
+            # logical operations with groups
+            elif input_list[0] == 'add':
+                ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
+                combined = add_atomgroups(ag_list).atoms
+                groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
+            elif input_list[0] == 'del':
+                groups_dict.pop(int(input_list[1]))
+
+            # help actions
+            elif input_list[0] == 'lg':
+                print_list_groups()
+            elif input_list[0] == 'h':
+                print_action_keys()
+
+
+print('\n########### Starting calculation ##########')
 t1 = perf_counter()
 if args.backend == 'serial':
     print('\n1- Getting the contacts between the groups over the frames in the trajectory:')
@@ -145,3 +230,7 @@ if args.r_bool:
     pdf.print_chapter('Warnings', warn2report)
     pdf.print_chapter('Compute summary', comp_stats)
     pdf.output(args.report, 'F')
+
+
+
+

--- a/bin/ufcc
+++ b/bin/ufcc
@@ -7,7 +7,6 @@ r"""Argument parser to use ufcc from the command-line
 """
 
 import argparse
-from tkinter import N
 import MDAnalysis as mda
 import ufcc._version as vers
 from ufcc import UFCC

--- a/bin/ufcc
+++ b/bin/ufcc
@@ -110,7 +110,7 @@ e  :  exit interactive selection and calculate de contacts between the Query and
     while input_key != 'e':
         print_help_message()
         input_key = input('>> ')
-        if input_key != 'e':
+        if input_key != 'e' and len(input_key) > 0:
             input_list = input_key.split()
 
             # updating database and query groups
@@ -144,6 +144,17 @@ e  :  exit interactive selection and calculate de contacts between the Query and
                 print_list_groups()
             elif input_list[0] == 'h':
                 print_action_keys()
+
+            # exit actions
+            else:
+                print('Unknown action key. Please type (h) to see the available action keys.')
+
+        elif input_key != 'e' and len(input_key) == 0:
+            print_help_message()
+            input_key = input('>> ')
+        else:
+            print('Exiting interactive selection.')
+            break
 
 
 print('\n########### Starting calculation ##########')

--- a/bin/ufcc
+++ b/bin/ufcc
@@ -64,12 +64,15 @@ with warnings.catch_warnings(record=True) as w:
 
 # For interactive selection of the groups for the contacts calculation
 if args.i_bool:
+    db_qr = {
+       'Database' : target_system.database.selected,
+        'Query' : target_system.query.selected
+    }
+
     groups_dict = {
-        0: ['Database', target_system.database.selected],
-        1: ['Query', target_system.query.selected],
-        2: ['System', target_system.query.whole.universe.atoms],
-        3: ['Protein', target_system.query.whole],
-        4: ['Lipids', target_system.database.whole]
+        0: ['System', target_system.query.whole.universe.atoms],
+        1: ['Protein', target_system.query.whole],
+        2: ['Lipids', target_system.database.whole]
     }
 
     groups_to_add = target_system.database.whole.universe.select_atoms('not protein').groupby('resnames')
@@ -90,9 +93,15 @@ e  :  exit interactive selection and calculate de contacts between the Query and
 ''')
 
     def print_list_groups():
-        print('\nList of groups:\n')
+        print('\nSelection groups:\n')
         for key, value in groups_dict.items():
             print('({}) : {} --> {} atoms'.format(key, value[0], value[1].n_atoms))
+
+    def print_db_qr():
+        print('\nDatabase and Query groups:\n')
+        for key, value in db_qr.items():
+            print('{} --> {} atoms'.format(key, value.n_atoms))
+        print('-----------------------------------------------------')
         
     def print_help_message():
         print('You can type (lg) to list the groups at any time, or (h) to review the available action keys with examples.')
@@ -103,6 +112,7 @@ e  :  exit interactive selection and calculate de contacts between the Query and
             combined = mda.Merge(combined, ag)
         return combined
 
+    print_db_qr()
     print_list_groups()
     print_action_keys()
     
@@ -141,6 +151,7 @@ e  :  exit interactive selection and calculate de contacts between the Query and
 
             # help actions
             elif input_list[0] == 'lg':
+                print_db_qr()
                 print_list_groups()
             elif input_list[0] == 'h':
                 print_action_keys()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-Ultr-Fast Contacts Calculation (UFCC)
+Ultra-Fast Contacts Calculation (UFCC)
 =======================================
 
 :Authors: Daniel P. Ramirez & Besian I. Sejdiu

--- a/ufcc/__init__.py
+++ b/ufcc/__init__.py
@@ -3,6 +3,7 @@
 # Add imports here
 import os
 from .ufcc import *
+from .interactive_sel import *
 
 # Handle versioneer
 from ._version import get_versions

--- a/ufcc/interactive_sel.py
+++ b/ufcc/interactive_sel.py
@@ -70,71 +70,110 @@ e  :  exit interactive selection and calculate de contacts between the Query and
 
             # updating database and query groups
             if input_list[0] == 'db':
-                if type(input_list[1]) != int:
-                    print('Error: Group_ID must be an integer.')
-                elif input_list[1] not in groups_dict.keys():
-                    print('Error: Group_ID must be a valid group ID.')
-                elif len(input_list) > 2:
+                if len(input_list) > 2:
                     print('Error: Too many arguments.')
+                elif len(input_list) < 2:
+                    print('Error: Too few arguments.')
                 else:
-                    target_system.database.select(groups_dict[int(input_list[1])][1])
-                    db_qr['Database'] = groups_dict[int(input_list[1])][1]
+                    try:
+                        int(input_list[1])
+                    except ValueError:
+                        print('Group_ID must be an integer.')
+                        continue
+                    if int(input_list[1]) not in groups_dict.keys():
+                        print('Error: Group_ID must be a valid group ID.')
+                    else:
+                        target_system.database.select(groups_dict[int(input_list[1])][1])
+                        db_qr['Database'] = groups_dict[int(input_list[1])][1]
             elif input_list[0] == 'qr':
-                if type(input_list[1]) != int:
-                    print('Error: Group_ID must be an integer.')
-                elif input_list[1] not in groups_dict.keys():
-                    print('Error: Group_ID must be a valid group ID.')
-                elif len(input_list) > 2:
+                if len(input_list) > 2:
                     print('Error: Too many arguments.')
+                elif len(input_list) < 2:
+                    print('Error: Too few arguments.')
                 else:
-                    target_system.query.select(groups_dict[int(input_list[1])][1])
-                    db_qr['Query'] = groups_dict[int(input_list[1])][1]
+                    try:
+                        int(input_list[1])
+                    except ValueError:
+                        print('Group_ID must be an integer.')
+                        continue
+                    if int(input_list[1]) not in groups_dict.keys():
+                        print('Error: Group_ID must be a valid group ID.')
+                    else:
+                        target_system.query.select(groups_dict[int(input_list[1])][1])
+                        db_qr['Query'] = groups_dict[int(input_list[1])][1]
 
             # creating subgroups
             elif input_list[0] == 'gb':
-                if type(input_list[1]) != int:
-                    print('Error: Group_ID must be an integer.')
-                elif input_list[1] not in groups_dict.keys():
-                    print('Error: Group_ID must be a valid group ID.')
-                elif input_list[2] not in target_system.query.whole.universe.atoms.attrs:
-                    print('Error: Attribute must be a valid attribute: {}.'.format(target_system.query.whole.universe.atoms.attrs))
-                elif len(input_list) > 3:
+                if len(input_list) > 3:
                     print('Error: Too many arguments.')
+                elif len(input_list) < 3:
+                    print('Error: Too few arguments.')
                 else:
-                    groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
-                    for label, ag in groups_to_add.items():
-                        groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
+                    try:
+                        int(input_list[1])
+                    except ValueError:
+                        print('Group_ID must be an integer.')
+                        continue
+                    if int(input_list[1]) not in groups_dict.keys():
+                        print('Error: Group_ID must be a valid group ID.')
+                    elif not hasattr(groups_dict[int(input_list[1])][1], input_list[2]):
+                        print('The attribute {} is not included in the topological attributes of this system.'.format(input_list[2]))
+                    else:
+                        groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
+                        for label, ag in groups_to_add.items():
+                            groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
             elif input_list[0] == 'sl':
-                if type(input_list[1]) != int:
-                    print('Error: Group_ID must be an integer.')
-                elif input_list[1] not in groups_dict.keys():
-                    print('Error: Group_ID must be a valid group ID.')
-                elif input_list[2] not in ['segment', 'residue', 'atom', 'molecule']:
-                    print('Error: Level must be a valid level: segment, residue, atom, molecule.')
-                elif len(input_list) > 3:
+                if len(input_list) > 3:
                     print('Error: Too many arguments.')
+                elif len(input_list) < 3:
+                    print('Error: Too few arguments.')
                 else:
-                    groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
-                    for ag in groups_to_add:
-                        groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
+                    try:
+                        int(input_list[1])
+                    except ValueError:
+                        print('Group_ID must be an integer.')
+                        continue
+                    if int(input_list[1]) not in groups_dict.keys():
+                        print('Error: Group_ID must be a valid group ID.')
+                    elif input_list[2] not in ['segment', 'residue', 'atom', 'molecule']:
+                        print('Error: Level must be a valid level: segment, residue, atom, molecule.')
+                    else:
+                        groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
+                        for ag in groups_to_add:
+                            groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
 
             # logical operations with groups
             elif input_list[0] == 'add':
-                if all([isinstance(item, int) for item in input_list[1:]]) and all([item in groups_dict.keys() for item in input_list[1:]]):  
-                    ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
-                    combined = add_atomgroups(ag_list).atoms
-                    groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
+                if len(input_list) < 3:
+                    print('Error: Too few arguments.')
                 else:
-                    print('Error: All Group_IDs must be integers included in the list of selection groups.')
+                    try:
+                        for i in range(1, len(input_list)):
+                            int(input_list[i])
+                    except ValueError:
+                        print('All Group_IDs must be integers.')
+                        continue
+                    if not all([int(item) in groups_dict.keys() for item in input_list[1:]]):  
+                        print('Error: All Group_IDs must be valid group IDs.')
+                    else:
+                        ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
+                        combined = add_atomgroups(ag_list).atoms
+                        groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
             elif input_list[0] == 'del':
-                if type(input_list[1]) != int:
-                    print('Error: Group_ID must be an integer.')
-                elif input_list[1] not in groups_dict.keys():
-                    print('Error: Group_ID must be a valid group ID.')
-                elif len(input_list) > 2:
+                if len(input_list) > 2:
                     print('Error: Too many arguments.')
+                elif len(input_list) < 2:
+                    print('Error: Too few arguments.')
                 else:
-                    groups_dict.pop(int(input_list[1]))
+                    try:
+                        int(input_list[1])
+                    except ValueError:
+                        print('Group_ID must be an integer.')
+                        continue
+                    if int(input_list[1]) not in groups_dict.keys():
+                        print('Error: Group_ID must be a valid group ID.')
+                    else:
+                        groups_dict.pop(int(input_list[1]))
 
             # help actions
             elif input_list[0] == 'lg':
@@ -154,8 +193,7 @@ e  :  exit interactive selection and calculate de contacts between the Query and
                 print('Unknown action key. Please type (h) to see the available action keys.')
 
         elif input_key != 'e' and len(input_key) == 0:
-            print_help_message()
-            input_key = input('>> ')
+            continue
         else:
             print('Exiting interactive selection.')
             break

--- a/ufcc/interactive_sel.py
+++ b/ufcc/interactive_sel.py
@@ -70,36 +70,84 @@ e  :  exit interactive selection and calculate de contacts between the Query and
 
             # updating database and query groups
             if input_list[0] == 'db':
-                target_system.database.select(groups_dict[int(input_list[1])][1])
-                db_qr['Database'] = groups_dict[int(input_list[1])][1]
+                if type(input_list[1]) != int:
+                    print('Error: Group_ID must be an integer.')
+                elif input_list[1] not in groups_dict.keys():
+                    print('Error: Group_ID must be a valid group ID.')
+                elif len(input_list) > 2:
+                    print('Error: Too many arguments.')
+                else:
+                    target_system.database.select(groups_dict[int(input_list[1])][1])
+                    db_qr['Database'] = groups_dict[int(input_list[1])][1]
             elif input_list[0] == 'qr':
-                target_system.query.select(groups_dict[int(input_list[1])][1])
-                db_qr['Query'] = groups_dict[int(input_list[1])][1]
+                if type(input_list[1]) != int:
+                    print('Error: Group_ID must be an integer.')
+                elif input_list[1] not in groups_dict.keys():
+                    print('Error: Group_ID must be a valid group ID.')
+                elif len(input_list) > 2:
+                    print('Error: Too many arguments.')
+                else:
+                    target_system.query.select(groups_dict[int(input_list[1])][1])
+                    db_qr['Query'] = groups_dict[int(input_list[1])][1]
 
             # creating subgroups
             elif input_list[0] == 'gb':
-                groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
-                for label, ag in groups_to_add.items():
-                    groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
+                if type(input_list[1]) != int:
+                    print('Error: Group_ID must be an integer.')
+                elif input_list[1] not in groups_dict.keys():
+                    print('Error: Group_ID must be a valid group ID.')
+                elif input_list[2] not in target_system.query.whole.universe.atoms.attrs:
+                    print('Error: Attribute must be a valid attribute: {}.'.format(target_system.query.whole.universe.atoms.attrs))
+                elif len(input_list) > 3:
+                    print('Error: Too many arguments.')
+                else:
+                    groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
+                    for label, ag in groups_to_add.items():
+                        groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
             elif input_list[0] == 'sl':
-                groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
-                for ag in groups_to_add:
-                    groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
+                if type(input_list[1]) != int:
+                    print('Error: Group_ID must be an integer.')
+                elif input_list[1] not in groups_dict.keys():
+                    print('Error: Group_ID must be a valid group ID.')
+                elif input_list[2] not in ['segment', 'residue', 'atom', 'molecule']:
+                    print('Error: Level must be a valid level: segment, residue, atom, molecule.')
+                elif len(input_list) > 3:
+                    print('Error: Too many arguments.')
+                else:
+                    groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
+                    for ag in groups_to_add:
+                        groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
 
             # logical operations with groups
             elif input_list[0] == 'add':
-                ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
-                combined = add_atomgroups(ag_list).atoms
-                groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
+                if all([isinstance(item, int) for item in input_list[1:]]) and all([item in groups_dict.keys() for item in input_list[1:]]):  
+                    ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
+                    combined = add_atomgroups(ag_list).atoms
+                    groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
+                else:
+                    print('Error: All Group_IDs must be integers included in the list of selection groups.')
             elif input_list[0] == 'del':
-                groups_dict.pop(int(input_list[1]))
+                if type(input_list[1]) != int:
+                    print('Error: Group_ID must be an integer.')
+                elif input_list[1] not in groups_dict.keys():
+                    print('Error: Group_ID must be a valid group ID.')
+                elif len(input_list) > 2:
+                    print('Error: Too many arguments.')
+                else:
+                    groups_dict.pop(int(input_list[1]))
 
             # help actions
             elif input_list[0] == 'lg':
-                print_db_qr()
-                print_list_groups()
+                if len(input_list) > 1:
+                    print('Error: Too many arguments.')
+                else:
+                    print_db_qr()
+                    print_list_groups()
             elif input_list[0] == 'h':
-                print_action_keys()
+                if len(input_list) > 1:
+                    print('Error: Too many arguments.')
+                else:
+                    print_action_keys()
 
             # exit actions
             else:

--- a/ufcc/interactive_sel.py
+++ b/ufcc/interactive_sel.py
@@ -1,0 +1,115 @@
+r"""Interactive selection of Database and Query
+======================================================
+:Authors: Daniel P. Ramirez & Besian I. Sejdiu
+:Year: 2022
+:Copyright: MIT License
+"""
+
+import MDAnalysis as mda
+
+
+def interactive_selection(target_system):
+    db_qr = {
+       'Database' : target_system.database.selected,
+        'Query' : target_system.query.selected
+    }
+
+    groups_dict = {
+        0: ['System', target_system.query.whole.universe.atoms],
+        1: ['Protein', target_system.query.whole],
+        2: ['Lipids', target_system.database.whole]
+    }
+
+    groups_to_add = target_system.database.whole.universe.select_atoms('not protein').groupby('resnames')
+    for label, ag in groups_to_add.items():
+        groups_dict[max(groups_dict.keys()) + 1] = ['{}'.format(label), ag]
+
+    def print_action_keys():
+        print('''\nActions keys:
+db  :  update database group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
+qr  :  update query group for contacts calculation. (i.e. >> d Group_ID) where Group_ID is the identifier of the group on the list of groups.
+gb :  create subgroups grouped by any topology attribute ("names", "resnames", "masses", etc). (i.e. >> gp Group_ID resnames) creates new groups for every different resname in the Group_ID selected.
+sl  :  create new groups by splitting a previous group at the desired level ("segment", "residue", "atom", "molecule"). (i.e. >> sl Group_ID residue) splits the Group_ID selected into all the residues that make it up, and create a new group for each of them.
+add:  merge two or more groups and create a new group with the combination. (i.e. >> add Group_ID1 Group_ID2 ... Group_IDn) creates a new group for the combination of the groups Group_ID1 Group_ID2 ... Group_IDn.
+del:  delete a group from the list of groups. (i.e. >> del Group_ID) remove the Group_ID selected.
+lg :  print the list of groups.
+h  :  print the help for all the available action keys.
+e  :  exit interactive selection and calculate de contacts between the Query and Database groups. 
+''')
+
+    def print_list_groups():
+        print('\nSelection groups:\n')
+        for key, value in groups_dict.items():
+            print('({}) : {} --> {} atoms'.format(key, value[0], value[1].n_atoms))
+
+    def print_db_qr():
+        print('\nDatabase and Query groups:\n')
+        for key, value in db_qr.items():
+            print('{} --> {} atoms'.format(key, value.n_atoms))
+        print('-----------------------------------------------------')
+        
+    def print_help_message():
+        print('You can type (lg) to list the groups at any time, or (h) to review the available action keys with examples.')
+
+    def add_atomgroups(ag_list):
+        combined = ag_list[0]
+        for ag in ag_list[1:]:
+            combined = mda.Merge(combined, ag)
+        return combined
+
+    print_db_qr()
+    print_list_groups()
+    print_action_keys()
+    
+    input_key = ''
+    while input_key != 'e':
+        print_help_message()
+        input_key = input('>> ')
+        if input_key != 'e' and len(input_key) > 0:
+            input_list = input_key.split()
+
+            # updating database and query groups
+            if input_list[0] == 'db':
+                target_system.database.select(groups_dict[int(input_list[1])][1])
+                db_qr['Database'] = groups_dict[int(input_list[1])][1]
+            elif input_list[0] == 'qr':
+                target_system.query.select(groups_dict[int(input_list[1])][1])
+                db_qr['Query'] = groups_dict[int(input_list[1])][1]
+
+            # creating subgroups
+            elif input_list[0] == 'gb':
+                groups_to_add = groups_dict[int(input_list[1])][1].groupby(input_list[2])
+                for label, ag in groups_to_add.items():
+                    groups_dict[max(groups_dict.keys()) + 1] = ['{} grouped by {} from {}'.format(label, input_list[2], groups_dict[int(input_list[1])][0]), ag]
+            elif input_list[0] == 'sl':
+                groups_to_add = groups_dict[int(input_list[1])][1].split(input_list[2])
+                for ag in groups_to_add:
+                    groups_dict[max(groups_dict.keys()) + 1] = ['{} splitted from {}'.format(input_list[2],groups_dict[int(input_list[1])][0]), ag]
+
+            # logical operations with groups
+            elif input_list[0] == 'add':
+                ag_list = [groups_dict[int(x)][1] for x in input_list[1:]]
+                combined = add_atomgroups(ag_list).atoms
+                groups_dict[max(groups_dict.keys()) + 1] = ['Group combined from {}'.format(input_list[1:]), combined]
+            elif input_list[0] == 'del':
+                groups_dict.pop(int(input_list[1]))
+
+            # help actions
+            elif input_list[0] == 'lg':
+                print_db_qr()
+                print_list_groups()
+            elif input_list[0] == 'h':
+                print_action_keys()
+
+            # exit actions
+            else:
+                print('Unknown action key. Please type (h) to see the available action keys.')
+
+        elif input_key != 'e' and len(input_key) == 0:
+            print_help_message()
+            input_key = input('>> ')
+        else:
+            print('Exiting interactive selection.')
+            break
+    return target_system
+


### PR DESCRIPTION
## Description
This PR implements an interactive selection of the groups that are going to be used for the calculation of the contacts (issue #9). The idea is quite similar to the make_ndx command of gromacs and the greatest advantage is that can be used for getting the contacts at any level (molecule, residue, atom) and between any two groups (not only lipid-protein).

## Features
Notable points that this PR has either accomplished:
  - [x] You can get into the interactive mode for the selection of the groups simply by typing `-i` or `-i True` when you are calling `ufcc` from the command-line.
  - [x] A list of groups is created by default where the groups `Database` and `Query` are the first two, and are the ones that will be used for the calculation of the contacts, so there are key actions that will allow the user to update these groups. Other than `Database` and `Query`, the list of groups included by default are: `System`, `Protein`, `Lipids`, and a group for any other resname included in `System` and not included in `Protein`, that can be for example: POPC, DOPC, POPE, SOL, SOD, CLA, LIG.
  - [x] You can update the `Database` and `Query` groups using the key actions `db` and `qr`, followed by the identifier of the group that you want to select as database or query for the calculation of the contacts.
  - [x] You can create new groups starting from the initial groups using two key actions: i) `gb` creates subgroups grouped by any topological attribute as for example the resnames, so you can do `gb 2 resnames`, where 2 is the identifier for the `Protein` group, and it will create a new group for each resname in the `Protein` group; and ii) `sl` creates new groups by splitting a previous group at the desired level ("segment", "residue", "atom", "molecule").
  - [x] You can merge two or more groups using the `add` key action as `add Group_ID1 Group_ID2 ... Group_IDn`, which creates a new group for the combination of the selected groups.
  - [x] Delete groups using `del Group_ID`.
  - [x] Print a list of the current groups with `lg`.
  - [x] Print a list of key actions using `h` (from help).
  - [x] Exit the interactive mode with `e`.
  
## Todos
Features to be added or that need to be resolved in order to merge the pull request.
- [x] Raise an error message if the structure of the command for each key actions does not match the expected structure.

## Status
- [x] Ready to go