### PR TITLE
Server ufcc calculations and working ganttApp 

### DIFF
--- a/bin/ufcc
+++ b/bin/ufcc
@@ -45,6 +45,12 @@ ufcc_parser.add_argument('-i', '--interactive', metavar='', type=bool, help='int
 # Executing the parse_args() method
 args = ufcc_parser.parse_args()
 
+print ('args', type(args), args)
+if args.backend == 'prolint_serial':
+    start_server(payload=args, reloader=False)
+    import sys
+    sys.exit()
+
 # Dealing with the MDAnalysis warnings, especially the ones about the mass, as this is quite common when loading Martini systems.
 mass_flag = 0
 mass_list = []
@@ -109,6 +115,10 @@ print('\n########## Thanks for using ufcc! #########\n')
 
 
 # payload = target_system.contacts.server_payload()
+# TODO:
+# for the backend to carry out the calculations, the payload
+# has to include file paths + uffc options. And it should be checked
+# very early on.
 if args.backend == 'prolint_serial':
     start_server(payload=payload, reloader=False)
 

--- a/ufcc/contacts.py
+++ b/ufcc/contacts.py
@@ -572,7 +572,7 @@ class Contacts(object):
             },
             {
                 "category": "Lipid 2",
-                "startFrame": 45,
+                "startFrame": 30,
                 "endFrame": 60,
             }
         ]

--- a/ufcc/contacts.py
+++ b/ufcc/contacts.py
@@ -124,6 +124,11 @@ class ProLintSerialContacts(AnalysisBase):
             # TODO:
             # @bis: we may be able to get further performance improvements by
             # using the Counter object with its update methods.
+
+            # TODO:
+            # these IDs are not guaranteed to be unique:
+            # For systems containing multiple proteins
+            # For very large systems with duplicate lipid residue IDs (e.g. two instances of 1234CHOL)
             lipid_name = self.db_resnames[p[1]]
             self.contacts_sum[residue_id][lipid_name] += 1
             self.contacts[residue_id][lipid_name].append(lipid_id)

--- a/ufcc/contacts.py
+++ b/ufcc/contacts.py
@@ -478,7 +478,7 @@ class Contacts(object):
         for residue, contact_counter in self.contacts_sum.items():
             for lipid, contact_sum in contact_counter.items():
                 sub_data[lipid]['value'] += contact_sum
-                metric = (contact_sum * self.dt) / self.totaltime # TODO: should we substract 1 frame here?
+                metric = (contact_sum * self.dt) / self.totaltime # TODO: do we have to substract 1 frame here?
                 js[protein][lipid].append([f'{resnames[residue]} {residue}', float("{:.2f}".format(metric))])
 
         sub_data = list(sub_data.values())

--- a/ufcc/contacts.py
+++ b/ufcc/contacts.py
@@ -93,8 +93,11 @@ class ProLintSerialContacts(AnalysisBase):
         self.query = query
         self.database = database
         self.cutoff = cutoff
-        self.q_resids = self.query.resindices
-        self.db_resids = self.database.resindices
+
+        # We need to convert to list to allow for JSON serialization
+        self.q_resids = self.query.resindices.tolist()
+        self.db_resids = self.database.resindices.tolist()
+
         self.db_resnames = self.database.resnames
         self.dp_resnames_unique = np.unique(self.db_resnames)
 

--- a/ufcc/contacts.py
+++ b/ufcc/contacts.py
@@ -109,6 +109,7 @@ class ProLintSerialContacts(AnalysisBase):
             raise ValueError("The cutoff must be greater than 0.")
 
     def _prepare(self):
+        print ('PREPARING contact_frames')
         self.contacts = {k: {v:[] for v in self.dp_resnames_unique} for k in self.q_resids}
         self.contacts_sum = {k: {v: 0 for v in self.dp_resnames_unique} for k in self.q_resids}
         self.contact_frames = {}
@@ -364,6 +365,7 @@ class Contacts(object):
 
         self.contacts = temp_instance.contacts
         self.contacts_sum = temp_instance.contacts_sum
+        self.contact_frames = temp_instance.contact_frames
 
     def save(self, path='contacts.pkl'):
         """

--- a/ufcc/server/server.py
+++ b/ufcc/server/server.py
@@ -4,6 +4,7 @@ import ast
 import json
 
 from bottle import route, run, template, debug, static_file, request
+from ufcc.contacts import ProLintSerialDistances
 
 from ufcc.ufcc import UFCC
 
@@ -123,6 +124,11 @@ def start_server(payload=None, debug_bool=False, reloader=True, port=8351):
     t, g = sort_lipids(ts)
     print (t['CHOL'][:10])
     print (g[3083])
+
+    ri = ProLintSerialDistances(ts.query.selected.universe, ts.query.selected, ts.database.selected, 2873, 53)
+    ri.run(verbose=False)
+    print (ri.distance_array)
+
     # Make data accessible globally
     global BACKEND_DATA
     BACKEND_DATA = payload

--- a/ufcc/server/server.py
+++ b/ufcc/server/server.py
@@ -86,7 +86,7 @@ def get_gantt_app_data(g, lipid_id, residues_to_show=10, intervals_to_filter_out
             if end - start < intervals_to_filter_out:
                 continue
             gantt_data.append({
-            "category": f'{lipid_id}-{res}',
+            "category": f'{res}',
             "startFrame": start,
             "endFrame": end,
             })
@@ -95,8 +95,6 @@ def get_gantt_app_data(g, lipid_id, residues_to_show=10, intervals_to_filter_out
     for x in [x['category'] for x in gantt_data]:
         if x not in categories:
             categories.append(x)
-    # categories = [x['category'] for x in gantt_data]
-    # categories = list(set(categories))
     return gantt_data, categories
 
 
@@ -183,16 +181,6 @@ def start_server(payload=None, debug_bool=False, reloader=True, port=8351):
     t, g = sort_lipids(ts)
     payload['top_lipids'] = t
     payload['lipid_contact_frames'] = g
-
-    # out = ts.contacts.contact_frames['999,2873']
-    # print ('out', ts.contacts.contact_frames.keys())
-    # print (len(ts.contacts.contact_frames.keys()))
-    # print (t)
-    # print (g)
-
-    # ri = ProLintSerialDistances(ts.query.selected.universe, ts.query.selected, ts.database.selected, 2873, 53)
-    # ri.run(verbose=False)
-    # print (ri.distance_array)
 
     # Make data accessible globally
     global BACKEND_DATA

--- a/ufcc/server/server.py
+++ b/ufcc/server/server.py
@@ -4,6 +4,8 @@ import json
 
 from bottle import route, run, template, debug, static_file, request
 
+from ufcc.ufcc import UFCC
+
 SERVER_PATH = os.path.abspath(os.path.dirname(__file__))
 
 BACKEND_DATA = None
@@ -50,6 +52,8 @@ def listener(metadata):
             lipid = BACKEND_DATA['lipids'][0]
             protein = BACKEND_DATA['proteins'][0]
         except:
+            print ('Detached EXECUTION')
+            print ('This is currently meant for testing only.')
             BACKEND_DATA = independent_execution()
             lipid = BACKEND_DATA['lipids'][0]
             protein = BACKEND_DATA['proteins'][0]
@@ -68,6 +72,14 @@ def listener(metadata):
 
 def start_server(payload=None, debug_bool=False, reloader=True, port=8351):
 
+    # UFCC calls:
+    args = payload
+    ts = UFCC(args.structure, args.trajectory, add_lipid_types = args.other_lipids)
+    ts.contacts.runner.backend = 'prolint_serial'
+    ts.contacts.compute(cutoff=args.cutoff)
+    payload = ts.contacts.server_payload()
+
+    # Make data accessible globally
     global BACKEND_DATA
     BACKEND_DATA = payload
 

--- a/ufcc/server/static/js/app.js
+++ b/ufcc/server/static/js/app.js
@@ -631,6 +631,7 @@ fetch('/data/' + JSON.stringify(obj))
         ganttSeries.columns.template.setAll({
             templateField: "columnSettings",
             strokeOpacity: 0,
+            fillOpacity: 0.5,
             tooltipText: "{category}"
         });
         ganttSeries.data.setAll(ganttData);

--- a/ufcc/server/static/js/app.js
+++ b/ufcc/server/static/js/app.js
@@ -21,6 +21,8 @@ fetch('/data/' + JSON.stringify(obj))
     .then(responseData => {
 
         // console.log('responseData', responseData);
+        console.log('top_lipids', responseData['globalTopLipids'])
+        console.log('lipid_contact_frames', responseData['lipidContactFrames'])
         var contactData = responseData['data'];
         var lipids = responseData['lipids'];
         var proteins = responseData['proteins'];

--- a/ufcc/server/static/js/app.js
+++ b/ufcc/server/static/js/app.js
@@ -615,7 +615,7 @@ fetch('/data/' + JSON.stringify(obj))
 
         var ganttXAxis = ganttChart.xAxes.push(am5xy.ValueAxis.new(ganttRoot, {
             min: 0,
-            max: 100,
+            strictMinMax: true,
             renderer: am5xy.AxisRendererX.new(ganttRoot, {})
         }));
 

--- a/ufcc/ufcc.py
+++ b/ufcc/ufcc.py
@@ -89,9 +89,10 @@ class UFCC(object):
     """
 
     def __init__(self, structure, trajectory, add_lipid_types=[]):
-        # TODO
+        # TODO:
         # @bis: use a variable for this query: self.atoms.select_atoms(protein_sel)
-        # We need to also store useful system information
+        # We need to also store useful system information (see below)
+        # TODO: maybe keep a reference to the universe object (=> ufcc.u)?
 
         # wrapping some basic MDAnalysis groups
         md = mda.Universe(structure, trajectory)


### PR DESCRIPTION
## Description
This PR links the ganttApp with real ProLint-generated data. It's an important milestone for #12 because it links up quite a few things internally.
 
## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] `ProLintSerialContacts` now keeps track of frames and, as such, indirectly, at distances. 
  - [x] ufcc calculations for the server has now been moved to the actual server rather than having a large payload sent to it. 
  - [x] Wrote a distance class that will get a distance array given a lipid and residue combo. 
  - [x] Improved various things in how the server works. 
  - [x] Several added functions in the backend make fetching information now possible and easy.  
  - [x] The ganttApp reads true backend generated data (no toy data anymore!)

## Status
- [x] Ready to go