### PR TITLE
40 adding new lipid types with al option in the command line

### DIFF
--- a/bin/ufcc
+++ b/bin/ufcc
@@ -57,6 +57,7 @@ ufcc_parser.add_argument(
     metavar="",
     help="additional lipid types to be included in the membrane group, supported lipid types are POPC, DPPC, DOPC, CHOL, CHL1, POPS and POPE.",
     dest="other_lipids",
+    default=[],
 )
 ufcc_parser.add_argument(
     "-i",
@@ -78,40 +79,4 @@ import sys
 
 sys.exit()
 
-# Dealing with the MDAnalysis warnings, especially the ones about the mass, as this is quite common when loading Martini systems.
-mass_flag = 0
-mass_list = []
-with warnings.catch_warnings(record=True) as w:
-    target_system = UFCC(
-        args.structure, args.trajectory, add_lipid_types=args.other_lipids
-    )
-    for warn in w:
-        syl = str(warn.message).split()
-        if syl[:5] == ["Failed", "to", "guess", "the", "mass"]:
-            mass_flag = +1
-            mass_list.append(syl[-1])
-        else:
-            print(warn.message)
-    if mass_flag > 0:
-        mass_warn = "Warning: Please be aware that UFCC could NOT guess the mass for the following atomtypes: {}. If you are using Martini or you are sure that this is not due to an error in your system you can ignore this message.".format(
-            ", ".join(mass_list)
-        )
-        print(mass_warn)
 
-# For interactive selection of the groups for the contacts calculation
-if args.i_bool:
-    target_system = interactive_selection(target_system)
-
-print("\n########### Starting calculation ##########")
-print("\n1- Getting the contacts between the groups over the frames in the trajectory:")
-payload = target_system.contacts.server_payload()
-
-print("\n################### Done! ##################")
-
-
-# payload = target_system.contacts.server_payload()
-# TODO:
-# for the backend to carry out the calculations, the payload
-# has to include file paths + ufcc options. And it should be checked
-# very early on.
-start_server(payload=payload, reloader=False, i_bool=False)

--- a/bin/ufcc
+++ b/bin/ufcc
@@ -39,7 +39,6 @@ ufcc_parser.add_argument(
     "trajectory", action="store", type=str, help="path to the trajectory file."
 )
 
-
 # optional arguments
 ufcc_parser.add_argument("-v", "--version", action="version")
 ufcc_parser.add_argument(
@@ -54,10 +53,9 @@ ufcc_parser.add_argument(
 ufcc_parser.add_argument(
     "-al",
     "--add_lipid_types",
+    nargs="+",
     metavar="",
-    type=list,
     help="additional lipid types to be included in the membrane group, supported lipid types are POPC, DPPC, DOPC, CHOL, CHL1, POPS and POPE.",
-    default=[],
     dest="other_lipids",
 )
 ufcc_parser.add_argument(
@@ -77,6 +75,7 @@ args = ufcc_parser.parse_args()
 # print("args", type(args), args)
 start_server(payload=args, reloader=False, i_bool=args.i_bool)
 import sys
+
 sys.exit()
 
 # Dealing with the MDAnalysis warnings, especially the ones about the mass, as this is quite common when loading Martini systems.
@@ -104,9 +103,7 @@ if args.i_bool:
     target_system = interactive_selection(target_system)
 
 print("\n########### Starting calculation ##########")
-print(
-    "\n1- Getting the contacts between the groups over the frames in the trajectory:"
-)
+print("\n1- Getting the contacts between the groups over the frames in the trajectory:")
 payload = target_system.contacts.server_payload()
 
 print("\n################### Done! ##################")

--- a/ufcc/config.ini
+++ b/ufcc/config.ini
@@ -3,7 +3,7 @@
 cutoff = 7  
 
 ; List of lipid types included during the initial definition of the membrane AtomGroup, this is used by default to set the *database*, which can be modified later either by entering in the interactive mode (-i) from the command line or using the python API.
-lipid_types = POPC, DPPC, DOPC, CHOL, CHL1, POPS, POPE
+lipid_types = DLPC, DPPC, DOPC, DIPC, POPC, DPPE, DOPE, POPE, DPPS, DOPS, POPS, DPPG, DOPG, POPG, DPPA, DOPA, POPA, DPPI, POPI, DPP1, POP1, DPP2, POP2, PODG, TOG, LPC, PPC, OPC, DPSM, POSM, DPCE, DPGS, DPG1, DPG3, DPMG, CHOL, CHL1
 
 ; Backend to run the contacts calculation (can be either *serial* or *parallel*).
 backend = serial


### PR DESCRIPTION
## Description
Fixing the command line option to add lipid types to be considered in the membrane database that are not included by default in the config.ini file.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fix the command line option.
  - [ ] Increase the number of lipid types included by default to be recognized in the membrane database. 

## Status
- [ ] Ready to go